### PR TITLE
MySQL 연동 및 JPA QueryDSL 의존성 추가, 테이블 매칭 엔티티 및 레포지토리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,18 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '3.4.2'
+
+    // https://mvnrepository.com/artifact/mysql/mysql-connector-java
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.33'
+
+    // https://mvnrepository.com/artifact/com.querydsl/querydsl-jpa
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dahye/speakerplatform/SpeakerPlatformApplication.java
+++ b/src/main/java/com/dahye/speakerplatform/SpeakerPlatformApplication.java
@@ -2,7 +2,9 @@ package com.dahye.speakerplatform;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SpeakerPlatformApplication {
 

--- a/src/main/java/com/dahye/speakerplatform/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/dahye/speakerplatform/common/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.dahye.speakerplatform.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "create_date")
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    @Column(name = "modify_date")
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/domain/Application.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/domain/Application.java
@@ -1,0 +1,20 @@
+package com.dahye.speakerplatform.lectures.domain;
+
+import com.dahye.speakerplatform.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "applications")
+public class Application extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "employee_no", nullable = false, length = 5)
+    private String employeeNo;
+
+    @ManyToOne
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/domain/Lecture.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/domain/Lecture.java
@@ -1,0 +1,33 @@
+package com.dahye.speakerplatform.lectures.domain;
+
+import com.dahye.speakerplatform.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "lectures")
+public class Lecture extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String lecturer;
+
+    @Column(nullable = false, length = 255)
+    private String location;
+
+    @Column(nullable = false)
+    private int capacity;
+
+    @Column(name = "current_capacity", nullable = false)
+    private int currentCapacity;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/repository/ApplicationRepository.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/repository/ApplicationRepository.java
@@ -1,0 +1,7 @@
+package com.dahye.speakerplatform.lectures.repository;
+
+import com.dahye.speakerplatform.lectures.domain.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/repository/LectureRepository.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/repository/LectureRepository.java
@@ -1,0 +1,7 @@
+package com.dahye.speakerplatform.lectures.repository;
+
+import com.dahye.speakerplatform.lectures.domain.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+}

--- a/src/main/java/com/dahye/speakerplatform/users/entity/User.java
+++ b/src/main/java/com/dahye/speakerplatform/users/entity/User.java
@@ -1,0 +1,26 @@
+package com.dahye.speakerplatform.users.entity;
+
+import com.dahye.speakerplatform.common.domain.BaseTimeEntity;
+import com.dahye.speakerplatform.users.enums.Role;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "employee_no", nullable = false, length = 5)
+    private String employeeNo;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+}

--- a/src/main/java/com/dahye/speakerplatform/users/enums/Role.java
+++ b/src/main/java/com/dahye/speakerplatform/users/enums/Role.java
@@ -1,0 +1,5 @@
+package com.dahye.speakerplatform.users.enums;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/main/java/com/dahye/speakerplatform/users/repository/UserRepository.java
+++ b/src/main/java/com/dahye/speakerplatform/users/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.dahye.speakerplatform.users.repository;
+
+import com.dahye.speakerplatform.users.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=speaker-platform-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  application:
+    name: speaker-platform-
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/lecture_management?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: localpw
+    driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
* MySQL 연동을 위한 YML 설정 업데이트
application.yml 파일을 수정하여 MySQL 연동을 위한 설정을 추가했습니다.

* JPA QueryDSL 의존성 추가
build.gradle 파일에 MySQL 및 JPA QueryDSL 의존성을 추가하여 쿼리 작성 지원을 개선했습니다.

* 테이블 매칭을 위한 엔티티 및 레포지토리 추가
새로운 테이블 매칭을 위한 엔티티 및 레포지토리 클래스를 추가했습니다.
  * Lecture, Application, User, Role 관련 엔티티 및 레포지토리 구현
  * BaseTimeEntity를 기반으로 하는 기본 엔티티 클래스 추가