### PR TITLE
Swagger 설정 추가 및 공통 응답 포맷 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dahye/speakerplatform/common/dto/response/AbstractPageResponse.java
+++ b/src/main/java/com/dahye/speakerplatform/common/dto/response/AbstractPageResponse.java
@@ -1,0 +1,22 @@
+package com.dahye.speakerplatform.common.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Schema(description = "페이지 응답 모델")
+@Getter
+@Setter
+@SuperBuilder
+public class AbstractPageResponse {
+
+    @Schema(description = "총 페이지 수")
+    private int totalPages;
+
+    @Schema(description = "마지막 페이지 여부")
+    private Boolean isLast;
+
+    @Schema(description = "총 개수")
+    private long totalElements;
+}

--- a/src/main/java/com/dahye/speakerplatform/common/dto/response/ServerResponse.java
+++ b/src/main/java/com/dahye/speakerplatform/common/dto/response/ServerResponse.java
@@ -1,0 +1,37 @@
+package com.dahye.speakerplatform.common.dto.response;
+
+import com.dahye.speakerplatform.common.enums.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class ServerResponse<T> {
+
+    private final ResponseCode code;
+    private final T content;
+
+    private ServerResponse(ResponseCode code) {
+        this.code = code;
+        this.content = null;
+    }
+
+    private ServerResponse(ResponseCode code, final T content) {
+        this.code = code;
+        this.content = content;
+    }
+
+    public static <T> ServerResponse<T> successResponse(final T content) {
+        return new ServerResponse<>(ResponseCode.SUCCESS, content);
+    }
+
+    public static <T> ServerResponse<T> successResponse() {
+        return new ServerResponse<>(ResponseCode.SUCCESS);
+    }
+
+    public static <T> ServerResponse<T> errorResponse(ResponseCode code) {
+        return new ServerResponse<>(code);
+    }
+
+    public static <T> ServerResponse<T> errorResponse(ResponseCode code, final T content) {
+        return new ServerResponse<>(code, content);
+    }
+}

--- a/src/main/java/com/dahye/speakerplatform/common/enums/ResponseCode.java
+++ b/src/main/java/com/dahye/speakerplatform/common/enums/ResponseCode.java
@@ -1,0 +1,19 @@
+package com.dahye.speakerplatform.common.enums;
+
+public enum ResponseCode {
+    // success
+    SUCCESS("Success", false),
+
+    // auth errors
+    UNAUTHORIZED("Unauthorized access", true),
+    FORBIDDEN("Access forbidden", true),
+    SERVER_ERROR("Internal server error", true);
+
+    public final boolean isFatality;
+    public final String message;
+
+    ResponseCode(String message, boolean isFatality) {
+        this.message = message;
+        this.isFatality = isFatality;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,20 @@ spring:
     username: root
     password: localpw
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+# Swagger springdoc-ui Configuration
+springdoc:
+  packages-to-scan: com.dahye.speakerplatform
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  cache:
+    disabled: true              # ?? ?? ??
+  api-docs:
+    path: /api-docs/json
+    groups:
+      enabled: true
+  swagger-ui:
+    enabled: true               # Swagger UI ???? : ?? ?? => <http://localhost:8080/swagger-ui/index.html>
+    path: /api-swagger.html         # Swagger UI ?? ?? ?? =>
+    tags-sorter: alpha          # alpha: ??? ? ?? ??, method: HTTP Method ? ??
+    operations-sorter: alpha    # alpha: ??? ? ?? ??, method: HTTP Method ? ??


### PR DESCRIPTION
**1. Swagger 설정 추가**
* Swagger를 설정하여 API 문서를 자동으로 생성할 수 있도록 했습니다.
* 이를 통해 개발자들이 API를 쉽게 이해하고, 테스트할 수 있는 환경을 제공합니다.

**2. 공통 응답 포맷 추가**
* 모든 API의 응답 포맷을 표준화하여 일관성 있는 응답 구조를 제공합니다.
* 이를 통해 API의 사용성과 유지보수성을 개선하였습니다.