### PR TITLE
관리자 강연 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '3.4.2'
 

--- a/src/main/java/com/dahye/speakerplatform/common/enums/ResponseCode.java
+++ b/src/main/java/com/dahye/speakerplatform/common/enums/ResponseCode.java
@@ -1,25 +1,33 @@
 package com.dahye.speakerplatform.common.enums;
 
 public enum ResponseCode {
-    // success
-    SUCCESS("Success", false),
+    SUCCESS("성공"),
+    SERVER_ERROR("서버 내부 오류"),
+    CREATED("생성 성공"),
 
-    // auth errors
-    UNAUTHORIZED("Unauthorized access", true),
-    FORBIDDEN("Access forbidden", true),
-    SERVER_ERROR("Internal server error", true),
+    // 인증 오류
+    UNAUTHORIZED("인증되지 않은 사용자"),
+    FORBIDDEN("접근이 금지되었습니다."),
 
-    // not found
-    NOT_FOUND_USER("User not found.", true),
+    // USER
+    NOT_FOUND_USER("사용자를 찾을 수 없습니다."),
 
     // invalid
-    INVALID_PASSWORD("Invalid password.", false);
+    INVALID_PASSWORD("잘못된 비밀번호입니다."),
+    INVALID_TIME_FORMAT("잘못된 데이터 형식입니다."),
 
-    public final boolean isFatality;
+    // 필수 값 누락
+    REQUIRED_EMPLOYEE_NO("사번은 필수 입력값입니다."),
+    REQUIRED_PASSWORD("비밀번호는 필수 입력값입니다."),
+    REQUIRED_LECTURER("강연자 정보는 필수 입력값입니다."),
+    REQUIRED_LOCATION("강연장 정보는 필수 입력값입니다."),
+    REQUIRED_CAPACITY("신청 가능 인원 수는 필수 입력값입니다."),
+    REQUIRED_START_TIME("강연 시작 시간은 필수 입력값입니다."),
+    REQUIRED_CONTENT("강연 내역 시간은 필수 입력값입니다.");
+
     public final String message;
 
-    ResponseCode(String message, boolean isFatality) {
+    ResponseCode(String message) {
         this.message = message;
-        this.isFatality = isFatality;
     }
 }

--- a/src/main/java/com/dahye/speakerplatform/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/dahye/speakerplatform/common/security/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                                 authorize
                                         .requestMatchers("/api/v1/auth/**", "/api-swagger.html", "/swagger-ui/**", "/api-docs/**")
                                         .permitAll()
+                                        .requestMatchers("/admin/**")
+                                        .hasRole("ADMIN")
                                         .anyRequest()
                                         .authenticated())
                 .exceptionHandling(e -> e.authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/src/main/java/com/dahye/speakerplatform/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dahye/speakerplatform/common/security/filter/JwtAuthenticationFilter.java
@@ -35,13 +35,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String jwt = token.substring(7);
             Claims claims = jwtService.parseToken(jwt);
 
-            String role = claims.get("role", String.class);
+            String role = claims.get("roles", String.class);
             Long customerId = Long.valueOf(claims.getSubject());
 
             List<SimpleGrantedAuthority> authorities = new ArrayList<>();
             authorities.add(new SimpleGrantedAuthority(role));
 
-            if ("ADMIN".equals(role)) {
+            if ("ROLE_ADMIN".equals(role)) {
                 authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
             }
 

--- a/src/main/java/com/dahye/speakerplatform/common/security/service/JwtService.java
+++ b/src/main/java/com/dahye/speakerplatform/common/security/service/JwtService.java
@@ -28,7 +28,7 @@ public class JwtService {
                 .setSubject(String.valueOf(id)) // 토큰의 주제 (사용자 식별 정보)
                 .setIssuedAt(new Date()) // 생성 시각
                 .setExpiration(new Date(System.currentTimeMillis() + 3600000)) // 유효 시간
-                .claim("role", role) // role 추가
+                .claim("roles", role) // role 추가
                 .signWith(key) // 서명
                 .compact();
     }

--- a/src/main/java/com/dahye/speakerplatform/common/util/DateUtil.java
+++ b/src/main/java/com/dahye/speakerplatform/common/util/DateUtil.java
@@ -1,0 +1,17 @@
+package com.dahye.speakerplatform.common.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+    private static final String DEFAULT_PATTERN = "yyyy-MM-dd HH:mm:ss";
+
+    public static LocalDateTime parseToLocalDateTime(String dateTimeStr, String pattern) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        return LocalDateTime.parse(dateTimeStr, formatter);
+    }
+
+    public static LocalDateTime parseToLocalDateTime(String dateTimeStr) {
+        return parseToLocalDateTime(dateTimeStr, DEFAULT_PATTERN);
+    }
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/controller/AdminLectureController.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/controller/AdminLectureController.java
@@ -1,0 +1,38 @@
+package com.dahye.speakerplatform.lectures.controller;
+
+import com.dahye.speakerplatform.common.dto.response.ServerResponse;
+import com.dahye.speakerplatform.common.enums.ResponseCode;
+import com.dahye.speakerplatform.lectures.dto.request.LectureCreateRequest;
+import com.dahye.speakerplatform.lectures.service.LectureService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "[ADMIN] LECTURES")
+@RestController
+@RequestMapping("/admin/api/v1/lectures")
+@RequiredArgsConstructor
+public class AdminLectureController {
+    private final LectureService lectureService;
+
+    @Operation(
+            summary = "강연 생성",
+            description = "관리자가 새로운 강연을 생성합니다."
+    )
+    @ApiResponse(responseCode = "201", description = "성공적으로 강연 내용이 생성되었습니다. ResponseCode = CREATED ",
+            content = @Content(schema = @Schema(implementation = ResponseCode.class)))
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("")
+    public ServerResponse<ResponseCode> createLecture(
+            @Valid @RequestBody LectureCreateRequest lectureCreateRequest) {
+
+        return ServerResponse.successResponse(
+                lectureService.createLecture(lectureCreateRequest));
+    }
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/domain/Lecture.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/domain/Lecture.java
@@ -2,10 +2,16 @@ package com.dahye.speakerplatform.lectures.domain;
 
 import com.dahye.speakerplatform.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "lectures")
 public class Lecture extends BaseTimeEntity {
 

--- a/src/main/java/com/dahye/speakerplatform/lectures/dto/request/LectureCreateRequest.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/dto/request/LectureCreateRequest.java
@@ -1,0 +1,41 @@
+package com.dahye.speakerplatform.lectures.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "강의 생성 요청 모델")
+@Getter
+@Setter
+public class LectureCreateRequest {
+
+    @Schema(description = "강연자")
+    @NotBlank(message = "REQUIRED_LECTURER")
+    @Size(max = 100, message = "MAX_LENGTH_LECTURER_EXCEEDS")
+    private String lecturer;
+
+    @Schema(description = "강연 장소")
+    @NotBlank(message = "REQUIRED_LOCATION")
+    @Size(max = 255, message = "MAX_LENGTH_LOCATION_EXCEEDS")
+    private String location;
+
+    @Schema(description = "신청 가능 인원 수")
+    @NotNull(message = "REQUIRED_CAPACITY")
+    private Integer capacity;
+
+    @Schema(description = "강연 시작 시간")
+    @NotNull(message = "REQUIRED_START_TIME")
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$", message = "INVALID_TIME_FORMAT")
+    private String startTime;
+
+    @Schema(description = "강연 내역")
+    @NotBlank(message = "REQUIRED_CONTENT")
+    private String content;
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/dto/request/LectureCreateRequest.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/dto/request/LectureCreateRequest.java
@@ -7,9 +7,6 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
 
 @Schema(description = "강의 생성 요청 모델")
 @Getter
@@ -32,7 +29,7 @@ public class LectureCreateRequest {
 
     @Schema(description = "강연 시작 시간")
     @NotNull(message = "REQUIRED_START_TIME")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$", message = "INVALID_TIME_FORMAT")
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}$", message = "INVALID_TIME_FORMAT")
     private String startTime;
 
     @Schema(description = "강연 내역")

--- a/src/main/java/com/dahye/speakerplatform/lectures/service/LectureService.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/service/LectureService.java
@@ -1,0 +1,31 @@
+package com.dahye.speakerplatform.lectures.service;
+
+import com.dahye.speakerplatform.common.enums.ResponseCode;
+import com.dahye.speakerplatform.common.util.DateUtil;
+import com.dahye.speakerplatform.lectures.domain.Lecture;
+import com.dahye.speakerplatform.lectures.dto.request.LectureCreateRequest;
+import com.dahye.speakerplatform.lectures.repository.LectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LectureService {
+    private final LectureRepository lectureRepository;
+
+    @Transactional
+    public ResponseCode createLecture(LectureCreateRequest lectureCreateRequest) {
+        Lecture lecture = Lecture.builder()
+                .lecturer(lectureCreateRequest.getLecturer())
+                .location(lectureCreateRequest.getLocation())
+                .capacity(lectureCreateRequest.getCapacity())
+                .content(lectureCreateRequest.getContent())
+                .currentCapacity(0)
+                .startTime(DateUtil.parseToLocalDateTime(lectureCreateRequest.getStartTime()))
+                .build();
+        lectureRepository.save(lecture);
+
+        return ResponseCode.CREATED;
+    }
+}

--- a/src/main/java/com/dahye/speakerplatform/users/controller/AuthController.java
+++ b/src/main/java/com/dahye/speakerplatform/users/controller/AuthController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,11 +30,7 @@ public class AuthController {
             content = @Content(schema = @Schema(implementation = String.class)))
     @PostMapping("/login")
     public ServerResponse<String> login(
-            @Valid @RequestBody LoginRequest loginRequest, BindingResult bindingResult) {
-
-        if (bindingResult != null && bindingResult.hasErrors()) {
-            throw new IllegalArgumentException(bindingResult.getAllErrors().get(0).getDefaultMessage());
-        }
+            @Valid @RequestBody LoginRequest loginRequest) {
 
         return ServerResponse.successResponse(
                 authService.login(loginRequest.getEmployeeNo(), loginRequest.getPassword()));

--- a/src/main/java/com/dahye/speakerplatform/users/enums/Role.java
+++ b/src/main/java/com/dahye/speakerplatform/users/enums/Role.java
@@ -1,5 +1,5 @@
 package com.dahye.speakerplatform.users.enums;
 
 public enum Role {
-    ADMIN, USER
+    ROLE_ADMIN, ROLE_USER
 }

--- a/src/test/java/com/dahye/speakerplatform/lectures/controller/LectureControllerCreateTest.java
+++ b/src/test/java/com/dahye/speakerplatform/lectures/controller/LectureControllerCreateTest.java
@@ -1,0 +1,67 @@
+package com.dahye.speakerplatform.lectures.controller;
+
+import com.dahye.speakerplatform.common.enums.ResponseCode;
+import com.dahye.speakerplatform.common.security.service.JwtService;
+import com.dahye.speakerplatform.lectures.dto.request.LectureCreateRequest;
+import com.dahye.speakerplatform.lectures.service.LectureService;
+import com.dahye.speakerplatform.users.controller.AuthController;
+import com.dahye.speakerplatform.users.dto.request.LoginRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminLectureController.class)
+@ExtendWith(MockitoExtension.class)
+@WithMockUser("TEST_USER")
+public class LectureControllerCreateTest {
+    private final String API_PATH = "/admin/api/v1/lectures";
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LectureService lectureService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("강연 생성 성공 테스트")
+    public void createTest() throws Exception {
+        // Given
+        LectureCreateRequest lectureCreateRequest = new LectureCreateRequest();
+        lectureCreateRequest.setLecturer("박다솔");
+        lectureCreateRequest.setLocation("경기도 화성시 남여울2길 4");
+        lectureCreateRequest.setCapacity(6);
+        lectureCreateRequest.setStartTime("2025-06-01 10:00:00");
+        lectureCreateRequest.setContent("체어 + 바렐 : 강의실에 오시면 당일 진행 방식(체어 또는 바렐)을 안내해 드립니다.");
+
+        Mockito.when(lectureService.createLecture(lectureCreateRequest)).thenReturn(ResponseCode.CREATED);
+
+        // When & Then
+        mockMvc.perform(post(API_PATH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(lectureCreateRequest))
+                        .with(csrf()))
+                .andDo(print()) // 출력
+                .andExpect(status().isCreated()) // 상태 코드가 200 OK인지 확인
+                .andExpect(jsonPath("$.content").value(ResponseCode.CREATED));
+    }
+}

--- a/src/test/java/com/dahye/speakerplatform/lectures/service/LectureServiceCreateTest.java
+++ b/src/test/java/com/dahye/speakerplatform/lectures/service/LectureServiceCreateTest.java
@@ -1,0 +1,43 @@
+package com.dahye.speakerplatform.lectures.service;
+
+import com.dahye.speakerplatform.common.enums.ResponseCode;
+import com.dahye.speakerplatform.lectures.domain.Lecture;
+import com.dahye.speakerplatform.lectures.dto.request.LectureCreateRequest;
+import com.dahye.speakerplatform.lectures.repository.LectureRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class LectureServiceCreateTest {
+    @InjectMocks
+    LectureService lectureService;
+
+    @Mock
+    LectureRepository lectureRepository;
+
+    @Test
+    @DisplayName("강연 생성 성공 테스트")
+    public void testLogin_Success() {
+        // Given
+        LectureCreateRequest lectureCreateRequest = new LectureCreateRequest();
+        lectureCreateRequest.setLecturer("박다솔");
+        lectureCreateRequest.setLocation("경기도 화성시 남여울2길 4");
+        lectureCreateRequest.setCapacity(6);
+        lectureCreateRequest.setStartTime("2025-06-01 10:00:00");
+        lectureCreateRequest.setContent("체어 + 바렐 : 강의실에 오시면 당일 진행 방식(체어 또는 바렐)을 안내해 드립니다.");
+
+        // When
+        ResponseCode responseCode = lectureService.createLecture(lectureCreateRequest);
+
+        // Then
+        assertEquals(ResponseCode.CREATED, responseCode);
+        Mockito.verify(lectureRepository, Mockito.times(1)).save(Mockito.any(Lecture.class));
+    }
+}

--- a/src/test/java/com/dahye/speakerplatform/users/service/AuthServiceLoginTest.java
+++ b/src/test/java/com/dahye/speakerplatform/users/service/AuthServiceLoginTest.java
@@ -42,7 +42,7 @@ public class AuthServiceLoginTest {
         User user = User.builder()
                 .id(1L)
                 .password(password)
-                .role(Role.USER)
+                .role(Role.ROLE_USER)
                 .build();
 
         Mockito.when(userRepository.findByEmployeeNo(employeeNo)).thenReturn(Optional.of(user));
@@ -84,7 +84,7 @@ public class AuthServiceLoginTest {
         User user = User.builder()
                 .id(1L)
                 .password("correctpassword")
-                .role(Role.USER)
+                .role(Role.ROLE_USER)
                 .build();
 
         // Mocking repository와 passwordEncoder


### PR DESCRIPTION
** 1. SecurityConfig 내 권한 관련 내용 추가 **
* /admin 으로 시작하는 API 는 ROLE_ADMIN의 권한이 있어야 접근할 수 있도록 설정했습니다.

** 2. 관리자 강연 생성 기능 구현 **
* 강연 생성 시, Request DTO 내 validation을 추가하여 필수 값이 누락되지 않도록 처리했습니다.