### PR TITLE
강연 신청자 내역 조회

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@
    - **설명**: 특정 강연에 신청한 사번 목록을 조회합니다.
    - **요청 파라미터**: `lecture_id`  
    - **응답 예시**:
+   ```json
+   {
+    "code": "SUCCESS",
+    "content": {
+        "totalPages": 1,
+        "isLast": true,
+        "totalElements": 4,
+        "applicantUserList": [
+            {
+                "employeeNo": "45678",
+                "applicationAt": "2025-02-27T16:05:46"
+            },
+            {
+                "employeeNo": "34567",
+                "applicationAt": "2025-02-27T16:02:32"
+            },
+            {
+                "employeeNo": "23456",
+                "applicationAt": "2025-02-27T15:55:08"
+            },
+            {
+                "employeeNo": "12345",
+                "applicationAt": "2025-02-27T15:55:08"
+            }
+            ]
+        }
+    }
+   ```
 
 ### Front API
 1. **강연 목록**  

--- a/src/main/java/com/dahye/speakerplatform/lectures/controller/AdminLectureApplicationController.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/controller/AdminLectureApplicationController.java
@@ -1,0 +1,35 @@
+package com.dahye.speakerplatform.lectures.controller;
+
+import com.dahye.speakerplatform.common.dto.response.ServerResponse;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserListResponse;
+import com.dahye.speakerplatform.lectures.dto.response.LectureListResponse;
+import com.dahye.speakerplatform.lectures.service.LectureApplicationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "[ADMIN] LECTURES")
+@RestController
+@RequestMapping("/admin/api/v1/lectures")
+@RequiredArgsConstructor
+public class AdminLectureApplicationController {
+    private final LectureApplicationService lectureApplicationService;
+
+    @Operation(
+            summary = "강연 신청자 목록",
+            description = "관리자가 강연의 신청자 목록을 확인합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "페이지 단위로 강연 신청자 정보가 응답됩니다.",
+            content = @Content(schema = @Schema(implementation = LectureListResponse.class)))
+    @GetMapping("/{lectureId}/applications")
+    public ServerResponse<ApplicantUserListResponse> getLectureApplicantUserList(@PathVariable Long lectureId,
+                                                                                 @RequestParam(value = "page", defaultValue = "0") int page,
+                                                                                 @RequestParam(value = "size", defaultValue = "10") int size) {
+        return ServerResponse.successResponse(
+                lectureApplicationService.getLectureApplicantUserList(lectureId, page, size));
+    }
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/dto/response/ApplicantUserListResponse.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/dto/response/ApplicantUserListResponse.java
@@ -1,0 +1,19 @@
+package com.dahye.speakerplatform.lectures.dto.response;
+
+import com.dahye.speakerplatform.common.dto.response.AbstractPageResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Schema(description = "강연 신청자 정보 리스트 응답 모델")
+@Getter
+@Setter
+@SuperBuilder
+public class ApplicantUserListResponse extends AbstractPageResponse {
+
+    @Schema(description = "강연 신청자 정보 리스트")
+    private List<ApplicantUserResponse> applicantUserList;
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/dto/response/ApplicantUserResponse.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/dto/response/ApplicantUserResponse.java
@@ -1,0 +1,19 @@
+package com.dahye.speakerplatform.lectures.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "강연 신청자 정보 응답 모델")
+@Getter
+@AllArgsConstructor
+public class ApplicantUserResponse {
+
+    @Schema(description = "사번")
+    private String employeeNo;
+
+    @Schema(description = "신청 시각")
+   private LocalDateTime applicationAt;
+}

--- a/src/main/java/com/dahye/speakerplatform/lectures/repository/ApplicationRepositoryCustom.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/repository/ApplicationRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.dahye.speakerplatform.lectures.repository;
 
 import com.dahye.speakerplatform.common.enums.SortDirection;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserResponse;
 import com.dahye.speakerplatform.lectures.dto.response.LectureApplicationResponse;
 import com.dahye.speakerplatform.lectures.enums.LectureApplicationSort;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ApplicationRepositoryCustom {
     Page<LectureApplicationResponse> getLectureApplicationListByLectureStartTime(int page, int size, String employeeNo, LectureApplicationSort sort, SortDirection sortDirection);
+
+    Page<ApplicantUserResponse> getLectureApplicantUserList(Long lectureId, Pageable pageable);
 }

--- a/src/main/java/com/dahye/speakerplatform/lectures/repository/ApplicationRepositoryCustomImpl.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/repository/ApplicationRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.dahye.speakerplatform.lectures.repository;
 
 import com.dahye.speakerplatform.common.enums.SortDirection;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserResponse;
 import com.dahye.speakerplatform.lectures.dto.response.LectureApplicationResponse;
 import com.dahye.speakerplatform.lectures.enums.LectureApplicationSort;
 import com.querydsl.core.types.OrderSpecifier;
@@ -84,5 +85,29 @@ public class ApplicationRepositoryCustomImpl implements ApplicationRepositoryCus
 
         return new PageImpl<>(lectureApplicationResponseList, pageable, total);
 
+    }
+
+    @Override
+    public Page<ApplicantUserResponse> getLectureApplicantUserList(Long lectureId, Pageable pageable) {
+
+        List<ApplicantUserResponse> applicantUserList = queryFactory
+                .select(Projections.constructor(ApplicantUserResponse.class,
+                        application.employeeNo,
+                        application.createdAt))
+                .from(application)
+                .innerJoin(application.lecture, lecture)
+                .on(lecture.id.eq(lectureId))
+                .orderBy(application.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(application.count())
+                .from(application)
+                .innerJoin(application.lecture, lecture)
+                .on(lecture.id.eq(lectureId)).fetchOne();
+
+        return new PageImpl<>(applicantUserList, pageable, total);
     }
 }

--- a/src/main/java/com/dahye/speakerplatform/lectures/service/LectureApplicationService.java
+++ b/src/main/java/com/dahye/speakerplatform/lectures/service/LectureApplicationService.java
@@ -5,6 +5,8 @@ import com.dahye.speakerplatform.common.enums.SortDirection;
 import com.dahye.speakerplatform.common.exception.customException.ApplicationException;
 import com.dahye.speakerplatform.lectures.domain.Application;
 import com.dahye.speakerplatform.lectures.domain.Lecture;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserListResponse;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserResponse;
 import com.dahye.speakerplatform.lectures.dto.response.LectureApplicationListResponse;
 import com.dahye.speakerplatform.lectures.dto.response.LectureApplicationResponse;
 import com.dahye.speakerplatform.lectures.enums.LectureApplicationSort;
@@ -13,6 +15,7 @@ import com.dahye.speakerplatform.lectures.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
@@ -283,5 +286,17 @@ public class LectureApplicationService {
         }
 
         return ResponseCode.CREATED;
+    }
+
+    @Transactional(readOnly = true)
+    public ApplicantUserListResponse getLectureApplicantUserList(Long lectureId, int page, int size) {
+        Page<ApplicantUserResponse> applicantUserList = applicationRepository.getLectureApplicantUserList(lectureId, PageRequest.of(page, size));
+
+        return ApplicantUserListResponse.builder()
+                .applicantUserList(applicantUserList.getContent())
+                .totalElements(applicantUserList.getTotalElements())
+                .totalPages(applicantUserList.getTotalPages())
+                .isLast(applicantUserList.isLast())
+                .build();
     }
 }

--- a/src/test/java/com/dahye/speakerplatform/lectures/controller/AdminLectureApplicationControllerGetApplicantListTest.java
+++ b/src/test/java/com/dahye/speakerplatform/lectures/controller/AdminLectureApplicationControllerGetApplicantListTest.java
@@ -1,0 +1,77 @@
+package com.dahye.speakerplatform.lectures.controller;
+
+import com.dahye.speakerplatform.common.security.service.JwtService;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserListResponse;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserResponse;
+import com.dahye.speakerplatform.lectures.service.LectureApplicationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+@WebMvcTest(AdminLectureApplicationController.class)
+@ExtendWith(MockitoExtension.class)
+@WithMockUser("TEST_USER")
+public class AdminLectureApplicationControllerGetApplicantListTest {
+    private final String API_PATH = "/admin/api/v1/lectures/{lecture_id}/applications";
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LectureApplicationService lectureApplicationService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("[ADMIN] 강연 신청자 목록 조회 성공 테스트")
+    public void getListTest() throws Exception {
+        ApplicantUserListResponse response = ApplicantUserListResponse.builder()
+                .totalPages(1)
+                .isLast(true)
+                .totalElements(4)
+                .applicantUserList(Arrays.asList(
+                        new ApplicantUserResponse("45678", LocalDateTime.parse("2025-02-27T16:05:46")),
+                        new ApplicantUserResponse("34567", LocalDateTime.parse("2025-02-27T16:02:32")),
+                        new ApplicantUserResponse("23456", LocalDateTime.parse("2025-02-27T15:55:08")),
+                        new ApplicantUserResponse("12345", LocalDateTime.parse("2025-02-27T15:55:08"))
+                ))
+                .build();
+
+        Long lectureId = 1L;
+        int page = 0;
+        int size = 10;
+
+        Mockito.when(lectureApplicationService.getLectureApplicantUserList(lectureId, page, size))
+                .thenReturn(response);
+
+        mockMvc.perform(get(API_PATH, lectureId)
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size)))
+                .andExpect(status().isOk())  // 응답 상태 200 OK 확인
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.content.totalPages").value(1))
+                .andExpect(jsonPath("$.content.isLast").value(true))
+                .andExpect(jsonPath("$.content.totalElements").value(4))
+                .andExpect(jsonPath("$.content.applicantUserList.length()").value(4))
+                .andExpect(jsonPath("$.content.applicantUserList[0].employeeNo").value("45678"))
+                .andExpect(jsonPath("$.content.applicantUserList[0].applicationAt").value("2025-02-27T16:05:46"));
+    }
+}

--- a/src/test/java/com/dahye/speakerplatform/lectures/service/LectureApplicationServiceGetApplicantListTest.java
+++ b/src/test/java/com/dahye/speakerplatform/lectures/service/LectureApplicationServiceGetApplicantListTest.java
@@ -1,0 +1,59 @@
+package com.dahye.speakerplatform.lectures.service;
+
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserListResponse;
+import com.dahye.speakerplatform.lectures.dto.response.ApplicantUserResponse;
+import com.dahye.speakerplatform.lectures.repository.ApplicationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class LectureApplicationServiceGetApplicantListTest {
+    @InjectMocks
+    private LectureApplicationService lectureApplicationService;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Test
+    @DisplayName("[ADMIN] 강연 신청자 목록 조회 성공 테스트")
+    public void applicantList_Success() {
+        Long lectureId = 1L;
+        int page = 0;
+        int size = 10;
+
+
+        Page<ApplicantUserResponse> pageResponse = new PageImpl<>(List.of(
+                new ApplicantUserResponse("45678", LocalDateTime.parse("2025-02-27T16:05:46")),
+                new ApplicantUserResponse("34567", LocalDateTime.parse("2025-02-27T16:02:32")),
+                new ApplicantUserResponse("23456", LocalDateTime.parse("2025-02-27T15:55:08")),
+                new ApplicantUserResponse("12345", LocalDateTime.parse("2025-02-27T15:55:08"))
+        ), Pageable.ofSize(size), 2);
+
+        Mockito.when(applicationRepository.getLectureApplicantUserList(lectureId, PageRequest.of(page, size)))
+                .thenReturn(pageResponse);
+
+        ApplicantUserListResponse result = lectureApplicationService.getLectureApplicantUserList(lectureId, page, size);
+
+        assertNotNull(result);
+        assertEquals(4, result.getApplicantUserList().size());
+        assertEquals(4, result.getTotalElements());
+        assertTrue(result.getIsLast());
+        verify(applicationRepository, times(1)).getLectureApplicantUserList(lectureId, PageRequest.of(page, size));
+    }
+}


### PR DESCRIPTION
**1. 강연 신청자 내역 조회 기능 구현**
* 강연 신청자 내역을 조회하는 기능을 컨트롤러 및 서비스에 추가했습니다.
* JUnit 5를 이용하여 관련 테스트 코드를 작성했습니다.
